### PR TITLE
Add support for passing `--color` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ optional arguments:
 
 sphinx's arguments:
   The following arguments are forwarded as-is to Sphinx. Please look at `sphinx --help` for more information.
-    -b=builder, -a, -E, -d=path, -j=N, -c=path, -C, -D=setting=value, -t=tag, -A=name=value, -n, -v, -q, -Q, -w=file, -W, -T, -N, -P
+    -b=builder, -a, -E, -d=path, -j=N, -c=path, -C, -D=setting=value, -t=tag, -A=name=value, -n, -v, -q, -Q, -w=file, -W, -T, -N, -P, --keep-going, --color
 ```
 
 ### Using with Makefile

--- a/src/sphinx_autobuild/build.py
+++ b/src/sphinx_autobuild/build.py
@@ -19,6 +19,7 @@ SPHINX_BUILD_OPTIONS = (
     ("A", "name=value"),
     ("n", None),
     ("N", None),
+    ("-color", None),
     ("v", None),
     ("q", None),
     ("Q", None),


### PR DESCRIPTION
Adds support for passing `sphinx-build`'s `--color` option to `sphinx-autobuild` and updates the docs for that and #109 