### PR TITLE
fix '--keep-going' sphinx argument error

### DIFF
--- a/src/sphinx_autobuild/cli.py
+++ b/src/sphinx_autobuild/cli.py
@@ -17,9 +17,10 @@ from .utils import find_free_port
 
 def _get_build_args(args):
     build_args = []
+    arg_dict = vars(args)  # Convert the args namespace to a dictionary
     for arg, meta in SPHINX_BUILD_OPTIONS:
-        val = getattr(args, arg)
-        if not val:
+        val = arg_dict.get(arg)
+        if val is None:
             continue
         opt = f"-{arg}"
         if meta is None:


### PR DESCRIPTION
#109 added `--keep-going` option but when used the `getattr` function call in `cli.py` was creating this error callback :

```console
Traceback (most recent call last):
  File ".venv/bin/sphinx-autobuild", line 8, in <module>
    sys.exit(main())
  File "/workspaces/comboard-linux-image/docs/.venv/src/sphinx-autobuild/src/sphinx_autobuild/cli.py", line 176, in main
    build_args, pre_build_commands = _get_build_args(args)
  File "/workspaces/comboard-linux-image/docs/.venv/src/sphinx-autobuild/src/sphinx_autobuild/cli.py", line 21, in _get_build_args
    val = getattr(args, arg)
AttributeError: 'Namespace' object has no attribute '-keep-going'
```

This MR fixes that bug by converting the args namespace to a dictonnary and using arg_dict.get instead.

I'm not sure how clean is this solution since it's no longer using `argparse` `getattr` function. I'm not a full time Python dev so feel free to change the code.

For more context, here's my original issue comment post : https://github.com/executablebooks/sphinx-autobuild/pull/109#issuecomment-1643891064