### PR TITLE
feat(cli): add post-build argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,7 @@ which can seen by running ``sphinx-autobuild --help``:
      --delay DELAY         how long to wait before opening the browser (default: 5)
      --watch DIR           additional directories to watch (default: [])
      --pre-build COMMAND   additional command(s) to run prior to building the documentation (default: [])
+     --post-build COMMAND  additional command(s) to run after building the documentation (default: [])
      --version             show program's version number and exit
 
    sphinx's arguments:
@@ -136,6 +137,14 @@ This results in slower builds, but it ensures that
 all pages are built from the same state of the HTML theme.
 It also works around a `known issue in Sphinx <relevant sphinx bugs_>`__
 which causes significant problems during theme development.
+
+Post-build resources can be processed by passing a user-defined command to
+``--post-build``.
+
+.. code-block:: bash
+   
+   --post-build "npx tailwindcss -i ./src/input.css -o ./src/output.css"
+
 
 Working on multiple projects
 ----------------------------

--- a/sphinx_autobuild/__main__.py
+++ b/sphinx_autobuild/__main__.py
@@ -34,12 +34,14 @@ def main():
     server = Server()
 
     pre_build_commands = list(map(shlex.split, args.pre_build))
+    post_build_commands = list(map(shlex.split, args.post_build))
     builder = Builder(
         server.watcher,
         build_args,
         host=args.host,
         port=port_num,
         pre_build_commands=pre_build_commands,
+        post_build_commands=post_build_commands,
     )
 
     ignore_handler = _get_ignore_handler(
@@ -175,6 +177,13 @@ def _add_autobuild_arguments(parser):
         metavar="COMMAND",
         default=[],
         help="additional command(s) to run prior to building the documentation",
+    )
+    group.add_argument(
+        "--post-build",
+        action="append",
+        metavar="COMMAND",
+        default=[],
+        help="additional command(s) to run after building the documentation",
     )
     return group
 


### PR DESCRIPTION
# Context

It is currently possible to run `pre-build` commands. In some situation, it can be interesting to run commands after sphinx-build, e.g. `tailwindcss`. 

# Proposal 

This PR adds support for `post-build` arguments copied on the existing `pre-build`.
