### PR TITLE
Add support for autobuilding -M within Sphinx

### DIFF
--- a/sphinx_autobuild/__main__.py
+++ b/sphinx_autobuild/__main__.py
@@ -97,6 +97,10 @@ def _get_sphinx_build_parser():
             # Fix the version
             action.version = f"%(prog)s {__version__}"
             break
+    sphinx_build_parser.add_argument(
+        "-M",
+        dest="make_builder",
+    )
     _add_autobuild_arguments(sphinx_build_parser)
 
     return sphinx_build_parser

--- a/sphinx_autobuild/build.py
+++ b/sphinx_autobuild/build.py
@@ -6,7 +6,7 @@ import subprocess
 from colorama import Fore, Style
 
 # This isn't public API, but we want to avoid a subprocess call
-from sphinx.cmd.build import build_main
+from sphinx.cmd.build import build_main, make_main
 from tornado import ioloop
 
 
@@ -65,7 +65,10 @@ class Builder:
         # NOTE:
         # sphinx.cmd.build.build_main is not considered to be public API,
         # but as this is a first-party project, we can cheat a little bit.
-        return_code = build_main(self.sphinx_args)
+        if self.sphinx_args[0] == "-M":
+            return_code = make_main(self.sphinx_args)
+        else:
+            return_code = build_main(self.sphinx_args)
         if return_code:
             print(f"Sphinx exited with exit code: {return_code}")
             print(


### PR DESCRIPTION
`sphinx-build` has a hiddenish entry point (it doesn't show up in `sphinx-build --help`) that is used for some build targets (see https://github.com/sphinx-doc/sphinx/blob/master/sphinx/cmd/build.py#L381-L384).  It's useful to be able to autobuild these, like `-M latexpdf`, beyond autobuilding the HTML targets.  There are PDF viewing programs that will autoreload when the PDF underneath changes, so this can be very useful for previewing the PDF output when one makes changes.

Additionally, the second patch allows multiple file changes to be consolidated into one build invocation of `sphinx-build` (at least while running with `pyinotify` installed which is automatically used by the `livereload` package if present).  This can occur when changing branches, for instance.  This is especially visible when doing a `latexpdf` build since it takes quite a bit longer than refreshing individual HTML files and it always fully rebuilds the project instead of individual files like a `html` build does.