### PR TITLE
Add watchfiles as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
   "uvicorn>=0.25",
   "websockets>=11.0",
   "colorama",
+  "watchfiles",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
The watchfiles dependency used in `server.py` is missing from requirements.

Since the changes 5 days ago, with a clean install, you get the following error:

```
$ sphinx-autobuild
Traceback (most recent call last):
  File "/.../sphinx-autobuild", line 5, in <module>
    from sphinx_autobuild.__main__ import main
  File "/.../sphinx_autobuild/__main__.py", line 22, in <module>
    from sphinx_autobuild.server import RebuildServer
  File "/.../sphinx_autobuild/server.py", line 8, in <module>
    import watchfiles
ModuleNotFoundError: No module named 'watchfiles'
```

After installing `watchfiles` the project runs successfully. This PR adds the package as a dependency in `pyproject.toml`.