### PR TITLE
Format and validate pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,29 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.15.2
     hooks:
       - id: pyupgrade
         args: [--py39-plus]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.10.1
+    rev: 24.4.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         files: \.py$
         args: ["--profile", "black"]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: flake8
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-builtin-literals
       - id: check-added-large-files
@@ -34,6 +34,16 @@ repos:
       - id: end-of-file-fixer
       - id: forbid-new-submodules
       - id: trailing-whitespace
+
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: 1.7.0
+    hooks:
+      - id: pyproject-fmt
+
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.16
+    hooks:
+      - id: validate-pyproject
 
   - repo: https://github.com/PyCQA/pydocstyle
     rev: 6.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,45 +1,42 @@
 [build-system]
-requires = ["flit_core>=3.7"]
 build-backend = "flit_core.buildapi"
+requires = [
+  "flit_core>=3.7",
+]
 
-# project metadata
 [project]
 name = "sphinx-autobuild"
 description = "Rebuild Sphinx documentation on changes, with hot reloading in the browser."
 readme = "README.rst"
-urls.Changelog = "https://github.com/sphinx-doc/sphinx-autobuild/blob/main/NEWS.rst"
-urls.Documentation = "https://github.com/sphinx-doc/sphinx-autobuild#readme"
-urls.Download = "https://pypi.org/project/sphinx-autobuild/"
-urls."Issue tracker" = "https://github.com/sphinx-doc/sphinx-autobuild/issues"
-urls.Source = "https://github.com/sphinx-doc/sphinx-autobuild"
 license.text = "MIT"
+authors = [{name = "Adam Turner"}, {name = "Jonathan Stoppani", email = "jonathan@stoppani.name"}]
 requires-python = ">=3.9"
-
-# Classifiers list: https://pypi.org/classifiers/
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "Environment :: Web Environment",
-    "Framework :: Sphinx",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
-    "Topic :: Documentation",
-    "Topic :: Documentation :: Sphinx",
-    "Topic :: Software Development",
-    "Topic :: Software Development :: Documentation",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Topic :: Utilities",
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: Console",
+  "Environment :: Web Environment",
+  "Framework :: Sphinx",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+  "Topic :: Documentation",
+  "Topic :: Documentation :: Sphinx",
+  "Topic :: Software Development",
+  "Topic :: Software Development :: Documentation",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: Utilities",
+]
+dynamic = [
+  "version",
 ]
 dependencies = [
   "colorama",
@@ -47,24 +44,21 @@ dependencies = [
   "starlette>=0.35",
   "uvicorn>=0.25",
   "watchfiles",
-  "websockets>=11.0",
+  "websockets>=11",
 ]
-dynamic = ["version"]
-
 [project.optional-dependencies]
-docs = []
-test = [
-    "pytest>=6.0",
-    "pytest-cov",
+docs = [
 ]
-
-[[project.authors]]
-name = "Adam Turner"
-
-[[project.authors]]
-name = "Jonathan Stoppani"
-email = "jonathan@stoppani.name"
-
+test = [
+  "pytest>=6",
+  "pytest-cov",
+]
+[project.urls]
+Changelog = "https://github.com/sphinx-doc/sphinx-autobuild/blob/main/NEWS.rst"
+Documentation = "https://github.com/sphinx-doc/sphinx-autobuild#readme"
+Download = "https://pypi.org/project/sphinx-autobuild/"
+"Issue tracker" = "https://github.com/sphinx-doc/sphinx-autobuild/issues"
+Source = "https://github.com/sphinx-doc/sphinx-autobuild"
 [project.scripts]
 sphinx-autobuild = "sphinx_autobuild.__main__:main"
 
@@ -77,6 +71,9 @@ include = [
     "tests/",
     "noxfile.py",
 ]
+
+[tool.pyproject-fmt]
+max_supported_python = "3.13"
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "sphinx",
   "starlette>=0.35",
   "uvicorn>=0.25",
-  "watchfiles",
+  "watchfiles>=0.20",
   "websockets>=11",
 ]
 [project.optional-dependencies]
@@ -51,7 +51,6 @@ docs = [
 ]
 test = [
   "pytest>=6",
-  "pytest-cov",
 ]
 [project.urls]
 Changelog = "https://github.com/sphinx-doc/sphinx-autobuild/blob/main/NEWS.rst"
@@ -74,20 +73,3 @@ include = [
 
 [tool.pyproject-fmt]
 max_supported_python = "3.13"
-
-[tool.coverage.run]
-branch = true
-omit = [
-  "*/conftest.py",
-  "docs/*",
-]
-
-[tool.coverage.report]
-exclude_lines = [
-  "pragma: no cover",
-  "NOCOV",
-  "if __name__ == .__main__.:"
-]
-
-[tool.coverage.html]
-directory = ".htmlcov"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,10 @@ name = "sphinx-autobuild"
 description = "Rebuild Sphinx documentation on changes, with hot reloading in the browser."
 readme = "README.rst"
 license.text = "MIT"
-authors = [{name = "Adam Turner"}, {name = "Jonathan Stoppani", email = "jonathan@stoppani.name"}]
+authors = [
+  {name = "Adam Turner"},
+  {name = "Jonathan Stoppani", email = "jonathan@stoppani.name"},
+]
 requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,12 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
+  "colorama",
   "sphinx",
   "starlette>=0.35",
   "uvicorn>=0.25",
+  "watchfiles",
   "websockets>=11.0",
-  "colorama",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
With the new sphinx-autobuild 2024.4.13, I'm getting `ModuleNotFoundError: No module named 'watchfiles'` with https://github.com/python/peps/:

```pytb
❯ make clean venv htmllive
rm -rf .venv
rm -rf build topic
Creating venv in .venv
Requirement already satisfied: pip in ./.venv/lib/python3.12/site-packages (24.0)
Collecting wheel
  Using cached wheel-0.43.0-py3-none-any.whl.metadata (2.2 kB)
Using cached wheel-0.43.0-py3-none-any.whl (65 kB)
Installing collected packages: wheel
Successfully installed wheel-0.43.0
Collecting Pygments>=2.9.0 (from -r requirements.txt (line 2))
  Using cached pygments-2.17.2-py3-none-any.whl.metadata (2.6 kB)
Collecting Sphinx!=6.1.0,!=6.1.1,>=5.1.1 (from -r requirements.txt (line 5))
  Using cached sphinx-7.2.6-py3-none-any.whl.metadata (5.9 kB)
Collecting docutils>=0.19.0 (from -r requirements.txt (line 6))
  Using cached docutils-0.21.1-py3-none-any.whl.metadata (2.7 kB)
Collecting sphinx-autobuild (from -r requirements.txt (line 8))
  Using cached sphinx_autobuild-2024.4.13-py3-none-any.whl.metadata (7.7 kB)
Collecting pytest (from -r requirements.txt (line 11))
  Using cached pytest-8.1.1-py3-none-any.whl.metadata (7.6 kB)
Collecting pytest-cov (from -r requirements.txt (line 12))
  Using cached pytest_cov-5.0.0-py3-none-any.whl.metadata (27 kB)
Collecting sphinxcontrib-applehelp (from Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached sphinxcontrib_applehelp-1.0.8-py3-none-any.whl.metadata (2.3 kB)
Collecting sphinxcontrib-devhelp (from Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached sphinxcontrib_devhelp-1.0.6-py3-none-any.whl.metadata (2.3 kB)
Collecting sphinxcontrib-jsmath (from Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl.metadata (1.4 kB)
Collecting sphinxcontrib-htmlhelp>=2.0.0 (from Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached sphinxcontrib_htmlhelp-2.0.5-py3-none-any.whl.metadata (2.3 kB)
Collecting sphinxcontrib-serializinghtml>=1.1.9 (from Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached sphinxcontrib_serializinghtml-1.1.10-py3-none-any.whl.metadata (2.4 kB)
Collecting sphinxcontrib-qthelp (from Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached sphinxcontrib_qthelp-1.0.7-py3-none-any.whl.metadata (2.2 kB)
Collecting Jinja2>=3.0 (from Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached Jinja2-3.1.3-py3-none-any.whl.metadata (3.3 kB)
Collecting docutils>=0.19.0 (from -r requirements.txt (line 6))
  Using cached docutils-0.20.1-py3-none-any.whl.metadata (2.8 kB)
Collecting snowballstemmer>=2.0 (from Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached snowballstemmer-2.2.0-py2.py3-none-any.whl.metadata (6.5 kB)
Collecting babel>=2.9 (from Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached Babel-2.14.0-py3-none-any.whl.metadata (1.6 kB)
Collecting alabaster<0.8,>=0.7 (from Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached alabaster-0.7.16-py3-none-any.whl.metadata (2.9 kB)
Collecting imagesize>=1.3 (from Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached imagesize-1.4.1-py2.py3-none-any.whl.metadata (1.5 kB)
Collecting requests>=2.25.0 (from Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached requests-2.31.0-py3-none-any.whl.metadata (4.6 kB)
Collecting packaging>=21.0 (from Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached packaging-24.0-py3-none-any.whl.metadata (3.2 kB)
Collecting starlette>=0.35 (from sphinx-autobuild->-r requirements.txt (line 8))
  Using cached starlette-0.37.2-py3-none-any.whl.metadata (5.9 kB)
Collecting uvicorn>=0.25 (from sphinx-autobuild->-r requirements.txt (line 8))
  Using cached uvicorn-0.29.0-py3-none-any.whl.metadata (6.3 kB)
Collecting websockets>=11.0 (from sphinx-autobuild->-r requirements.txt (line 8))
  Using cached websockets-12.0-cp312-cp312-macosx_11_0_arm64.whl.metadata (6.6 kB)
Collecting colorama (from sphinx-autobuild->-r requirements.txt (line 8))
  Using cached colorama-0.4.6-py2.py3-none-any.whl.metadata (17 kB)
Collecting iniconfig (from pytest->-r requirements.txt (line 11))
  Using cached iniconfig-2.0.0-py3-none-any.whl.metadata (2.6 kB)
Collecting pluggy<2.0,>=1.4 (from pytest->-r requirements.txt (line 11))
  Using cached pluggy-1.4.0-py3-none-any.whl.metadata (4.3 kB)
Collecting coverage>=5.2.1 (from coverage[toml]>=5.2.1->pytest-cov->-r requirements.txt (line 12))
  Using cached coverage-7.4.4-cp312-cp312-macosx_11_0_arm64.whl.metadata (8.2 kB)
Collecting MarkupSafe>=2.0 (from Jinja2>=3.0->Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_universal2.whl.metadata (3.0 kB)
Collecting charset-normalizer<4,>=2 (from requests>=2.25.0->Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl.metadata (33 kB)
Collecting idna<4,>=2.5 (from requests>=2.25.0->Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached idna-3.7-py3-none-any.whl.metadata (9.9 kB)
Collecting urllib3<3,>=1.21.1 (from requests>=2.25.0->Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached urllib3-2.2.1-py3-none-any.whl.metadata (6.4 kB)
Collecting certifi>=2017.4.17 (from requests>=2.25.0->Sphinx!=6.1.0,!=6.1.1,>=5.1.1->-r requirements.txt (line 5))
  Using cached certifi-2024.2.2-py3-none-any.whl.metadata (2.2 kB)
Collecting anyio<5,>=3.4.0 (from starlette>=0.35->sphinx-autobuild->-r requirements.txt (line 8))
  Using cached anyio-4.3.0-py3-none-any.whl.metadata (4.6 kB)
Collecting click>=7.0 (from uvicorn>=0.25->sphinx-autobuild->-r requirements.txt (line 8))
  Using cached click-8.1.7-py3-none-any.whl.metadata (3.0 kB)
Collecting h11>=0.8 (from uvicorn>=0.25->sphinx-autobuild->-r requirements.txt (line 8))
  Using cached h11-0.14.0-py3-none-any.whl.metadata (8.2 kB)
Collecting sniffio>=1.1 (from anyio<5,>=3.4.0->starlette>=0.35->sphinx-autobuild->-r requirements.txt (line 8))
  Using cached sniffio-1.3.1-py3-none-any.whl.metadata (3.9 kB)
Using cached pygments-2.17.2-py3-none-any.whl (1.2 MB)
Using cached sphinx-7.2.6-py3-none-any.whl (3.2 MB)
Using cached docutils-0.20.1-py3-none-any.whl (572 kB)
Using cached sphinx_autobuild-2024.4.13-py3-none-any.whl (11 kB)
Using cached pytest-8.1.1-py3-none-any.whl (337 kB)
Using cached pytest_cov-5.0.0-py3-none-any.whl (21 kB)
Using cached alabaster-0.7.16-py3-none-any.whl (13 kB)
Using cached Babel-2.14.0-py3-none-any.whl (11.0 MB)
Using cached coverage-7.4.4-cp312-cp312-macosx_11_0_arm64.whl (206 kB)
Using cached imagesize-1.4.1-py2.py3-none-any.whl (8.8 kB)
Using cached Jinja2-3.1.3-py3-none-any.whl (133 kB)
Using cached packaging-24.0-py3-none-any.whl (53 kB)
Using cached pluggy-1.4.0-py3-none-any.whl (20 kB)
Using cached requests-2.31.0-py3-none-any.whl (62 kB)
Using cached snowballstemmer-2.2.0-py2.py3-none-any.whl (93 kB)
Using cached sphinxcontrib_htmlhelp-2.0.5-py3-none-any.whl (99 kB)
Using cached sphinxcontrib_serializinghtml-1.1.10-py3-none-any.whl (92 kB)
Using cached starlette-0.37.2-py3-none-any.whl (71 kB)
Using cached uvicorn-0.29.0-py3-none-any.whl (60 kB)
Using cached websockets-12.0-cp312-cp312-macosx_11_0_arm64.whl (121 kB)
Using cached colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Using cached iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
Using cached sphinxcontrib_applehelp-1.0.8-py3-none-any.whl (120 kB)
Using cached sphinxcontrib_devhelp-1.0.6-py3-none-any.whl (83 kB)
Using cached sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl (5.1 kB)
Using cached sphinxcontrib_qthelp-1.0.7-py3-none-any.whl (89 kB)
Using cached anyio-4.3.0-py3-none-any.whl (85 kB)
Using cached certifi-2024.2.2-py3-none-any.whl (163 kB)
Using cached charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl (119 kB)
Using cached click-8.1.7-py3-none-any.whl (97 kB)
Using cached h11-0.14.0-py3-none-any.whl (58 kB)
Using cached idna-3.7-py3-none-any.whl (66 kB)
Using cached MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_universal2.whl (18 kB)
Using cached urllib3-2.2.1-py3-none-any.whl (121 kB)
Using cached sniffio-1.3.1-py3-none-any.whl (10 kB)
Installing collected packages: snowballstemmer, websockets, urllib3, sphinxcontrib-serializinghtml, sphinxcontrib-qthelp, sphinxcontrib-jsmath, sphinxcontrib-htmlhelp, sphinxcontrib-devhelp, sphinxcontrib-applehelp, sniffio, Pygments, pluggy, packaging, MarkupSafe, iniconfig, imagesize, idna, h11, docutils, coverage, colorama, click, charset-normalizer, certifi, babel, alabaster, uvicorn, requests, pytest, Jinja2, anyio, starlette, Sphinx, pytest-cov, sphinx-autobuild
Successfully installed Jinja2-3.1.3 MarkupSafe-2.1.5 Pygments-2.17.2 Sphinx-7.2.6 alabaster-0.7.16 anyio-4.3.0 babel-2.14.0 certifi-2024.2.2 charset-normalizer-3.3.2 click-8.1.7 colorama-0.4.6 coverage-7.4.4 docutils-0.20.1 h11-0.14.0 idna-3.7 imagesize-1.4.1 iniconfig-2.0.0 packaging-24.0 pluggy-1.4.0 pytest-8.1.1 pytest-cov-5.0.0 requests-2.31.0 sniffio-1.3.1 snowballstemmer-2.2.0 sphinx-autobuild-2024.4.13 sphinxcontrib-applehelp-1.0.8 sphinxcontrib-devhelp-1.0.6 sphinxcontrib-htmlhelp-2.0.5 sphinxcontrib-jsmath-1.0.1 sphinxcontrib-qthelp-1.0.7 sphinxcontrib-serializinghtml-1.1.10 starlette-0.37.2 urllib3-2.2.1 uvicorn-0.29.0 websockets-12.0
The venv has been created in the .venv directory
.venv/bin/sphinx-autobuild -b html -j auto  --re-ignore="/\.idea/|/venv/|/pep-0000.rst|/topic/" --open-browser --delay 0 peps build
Traceback (most recent call last):
  File "/Users/hugo/github/peps/.venv/bin/sphinx-autobuild", line 5, in <module>
    from sphinx_autobuild.__main__ import main
  File "/Users/hugo/github/peps/.venv/lib/python3.12/site-packages/sphinx_autobuild/__main__.py", line 22, in <module>
    from sphinx_autobuild.server import RebuildServer
  File "/Users/hugo/github/peps/.venv/lib/python3.12/site-packages/sphinx_autobuild/server.py", line 8, in <module>
    import watchfiles
ModuleNotFoundError: No module named 'watchfiles'
make: *** [html] Error 1
```
