### PR TITLE
[MISC] Fix build in py39

### DIFF
--- a/sphinx_autobuild/server.py
+++ b/sphinx_autobuild/server.py
@@ -24,7 +24,13 @@ class RebuildServer:
         ignore_filter: IgnoreFilter,
         change_callback: Callable[[], None],
     ) -> None:
-        self.paths = [os.path.realpath(path, strict=True) for path in paths]
+        self.paths = [os.path.realpath(path) for path in paths]
+
+        # Santiy check the paths
+        for p in self.paths:
+            if not os.path.exists(p):
+                raise FileNotFoundError(p)
+
         self.ignore = ignore_filter
         self.change_callback = change_callback
         self.flag = asyncio.Event()


### PR DESCRIPTION
Don't use `realpath(... strict=True)` which isn't available in py3.9. Instead explicitly check whether the given paths exist.

Fixes #155 .
