### PR TITLE
Update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,6 @@
-ci:
-  autofix_prs: true
-  autoupdate_commit_msg: "[pre-commit.ci] pre-commit suggestions"
-  autoupdate_schedule: quarterly
-
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.5.7
     hooks:
       - id: ruff
       - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,8 @@
+ci:
+  autofix_prs: true
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit suggestions"
+  autoupdate_schedule: quarterly
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.7
+    rev: v0.4.4
     hooks:
       - id: ruff
       - id: ruff-format
@@ -19,11 +19,11 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 1.7.0
+    rev: 2.1.1
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.16
+    rev: v0.17
     hooks:
       - id: validate-pyproject

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "flit_core.buildapi"
 requires = [
-  "flit_core>=3.7",
+  "flit-core>=3.7",
 ]
 
 [project]
@@ -10,8 +10,8 @@ description = "Rebuild Sphinx documentation on changes, with hot reloading in th
 readme = "README.rst"
 license.text = "MIT"
 authors = [
-  {name = "Adam Turner"},
-  {name = "Jonathan Stoppani", email = "jonathan@stoppani.name"},
+  { name = "Adam Turner" },
+  { name = "Jonathan Stoppani", email = "jonathan@stoppani.name" },
 ]
 requires-python = ">=3.9"
 classifiers = [
@@ -49,30 +49,27 @@ dependencies = [
   "watchfiles>=0.20",
   "websockets>=11",
 ]
-[project.optional-dependencies]
-docs = [
+optional-dependencies.docs = [
 ]
-test = [
+optional-dependencies.test = [
   "httpx",
   "pytest>=6",
 ]
-[project.urls]
-Changelog = "https://github.com/sphinx-doc/sphinx-autobuild/blob/main/NEWS.rst"
-Documentation = "https://github.com/sphinx-doc/sphinx-autobuild#readme"
-Download = "https://pypi.org/project/sphinx-autobuild/"
-"Issue tracker" = "https://github.com/sphinx-doc/sphinx-autobuild/issues"
-Source = "https://github.com/sphinx-doc/sphinx-autobuild"
-[project.scripts]
-sphinx-autobuild = "sphinx_autobuild.__main__:main"
+urls.Changelog = "https://github.com/sphinx-doc/sphinx-autobuild/blob/main/NEWS.rst"
+urls.Documentation = "https://github.com/sphinx-doc/sphinx-autobuild#readme"
+urls.Download = "https://pypi.org/project/sphinx-autobuild/"
+urls."Issue tracker" = "https://github.com/sphinx-doc/sphinx-autobuild/issues"
+urls.Source = "https://github.com/sphinx-doc/sphinx-autobuild"
+scripts.sphinx-autobuild = "sphinx_autobuild.__main__:main"
 
 [tool.flit.sdist]
 include = [
-    "AUTHORS.rst",
-    "LICENSE.rst",
-    "NEWS.rst",
-    # Tests
-    "tests/",
-    "noxfile.py",
+  "AUTHORS.rst",
+  "LICENSE.rst",
+  "NEWS.rst",
+  # Tests
+  "tests/",
+  "noxfile.py",
 ]
 
 [tool.pyproject-fmt]


### PR DESCRIPTION
Running regular update `pre-commit autoupdate`...

Moreover curious if it would be possible to install this [bot](https://github.com/marketplace/pre-commit-ci), which would help with fixing open PRs and do these regular updates automatically (via PR so all is validated before merge)

```yaml
ci:
  autofix_prs: true
  autoupdate_commit_msg: "[pre-commit.ci] pre-commit suggestions"
  autoupdate_schedule: quarterly
  # submodules: true
```

cc: @AA-Turner @hugovk