### PR TITLE
Don't require the output dir to exist at startup, it might not exist yet

### DIFF
--- a/sphinx_autobuild/__main__.py
+++ b/sphinx_autobuild/__main__.py
@@ -98,7 +98,7 @@ def _parse_args(argv):
 
     # Copy needed settings
     args.sourcedir = Path(sphinx_args.sourcedir).resolve(strict=True)
-    args.outdir = Path(sphinx_args.outputdir).resolve(strict=True)
+    args.outdir = Path(sphinx_args.outputdir).resolve()
     if sphinx_args.doctreedir:
         args.doctree_dir = Path(sphinx_args.doctreedir).resolve(strict=True)
     else:

--- a/sphinx_autobuild/__main__.py
+++ b/sphinx_autobuild/__main__.py
@@ -104,7 +104,7 @@ def _parse_args(argv):
     else:
         args.doctree_dir = None
     if sphinx_args.warnfile:
-        args.warnings_file = Path(sphinx_args.warnfile).resolve(strict=True)
+        args.warnings_file = Path(sphinx_args.warnfile).resolve()
     else:
         args.warnings_file = None
 

--- a/sphinx_autobuild/__main__.py
+++ b/sphinx_autobuild/__main__.py
@@ -100,7 +100,7 @@ def _parse_args(argv):
     args.sourcedir = Path(sphinx_args.sourcedir).resolve(strict=True)
     args.outdir = Path(sphinx_args.outputdir).resolve()
     if sphinx_args.doctreedir:
-        args.doctree_dir = Path(sphinx_args.doctreedir).resolve(strict=True)
+        args.doctree_dir = Path(sphinx_args.doctreedir).resolve()
     else:
         args.doctree_dir = None
     if sphinx_args.warnfile:


### PR DESCRIPTION
Fixes https://github.com/sphinx-doc/sphinx-autobuild/issues/177.

With sphinx-autobuild 2023.9.3 and the https://github.com/python/peps repo:

```pytb
❯ make clean
rm -rf .venv
rm -rf build topic
❯ sphinx-autobuild --builder html --jobs auto  --re-ignore="/\.idea/|/venv/|/pep-0000.rst|/topic/" --open-browser --delay 0 --port 55302 peps build
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.13/bin/sphinx-autobuild", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/sphinx_autobuild/__main__.py", line 34, in main
    args, build_args = _parse_args(list(argv))
                       ~~~~~~~~~~~^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/sphinx_autobuild/__main__.py", line 101, in _parse_args
    args.outdir = Path(sphinx_args.outputdir).resolve(strict=True)
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py", line 670, in resolve
    return self.with_segments(os.path.realpath(self, strict=strict))
                              ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 439, in realpath
FileNotFoundError: [Errno 2] No such file or directory: '/Users/hugo/github/peps/build'
```

With 2024.4.16 it gets further, then another error and servers the page showing "Not Found":

```diff
diff --git a/Makefile b/Makefile
 .PHONY: _ensure-sphinx-autobuild
 _ensure-sphinx-autobuild:
-	make _ensure-package PACKAGE=sphinx-autobuild
+	make _ensure-package PACKAGE=sphinx-autobuild==2024.4.16
```

```console
❯ make clean
rm -rf .venv
rm -rf build topic
❯ sphinx-autobuild --builder html --jobs auto  --re-ignore="/\.idea/|/venv/|/pep-0000.rst|/topic/" --open-browser --delay 0 --port 55302 peps build
[sphinx-autobuild] Starting initial build
[sphinx-autobuild] > sphinx-build --builder html --jobs auto peps build
Running Sphinx v8.0.2
loading translations [en]... done
loading intersphinx inventory 'python' from https://docs.python.org/3//objects.inv ...
loading intersphinx inventory 'packaging' from https://packaging.python.org/en/latest//objects.inv ...
loading intersphinx inventory 'typing' from https://typing.readthedocs.io/en/latest//objects.inv ...
loading intersphinx inventory 'trio' from https://trio.readthedocs.io/en/latest//objects.inv ...
loading intersphinx inventory 'devguide' from https://devguide.python.org//objects.inv ...
loading intersphinx inventory 'py3.11' from https://docs.python.org/3.11//objects.inv ...
loading intersphinx inventory 'py3.12' from https://docs.python.org/3.12//objects.inv ...
loading intersphinx inventory 'py3.13' from https://docs.python.org/3.13//objects.inv ...
intersphinx inventory has moved: https://trio.readthedocs.io/en/latest//objects.inv -> https://trio.readthedocs.io/en/latest/objects.inv
intersphinx inventory has moved: https://typing.readthedocs.io/en/latest//objects.inv -> https://typing.readthedocs.io/en/latest/objects.inv
intersphinx inventory has moved: https://packaging.python.org/en/latest//objects.inv -> https://packaging.python.org/en/latest/objects.inv
building [html]: targets for 659 source files that are out of date
updating environment: [new config] 659 added, 0 changed, 0 removed
reading sources... [100%] pep-8014 .. topic/typing
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets...
copying static files... done
copying extra files... done
copying assets: done
writing output... [100%] pep-8013 .. topic/typing
generating indices... done
writing additional pages... done
copying images... [100%] pep-3147-1.png
dumping object inventory... done

Extension error (pep_sphinx_extensions):
Handler <function _post_build at 0x107e87380> for event 'build-finished' threw an exception (exception: cannot import name 'create_index_file' from 'build' (/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/build/__init__.py))
Sphinx exited with exit code: 2
The server will continue serving the build folder, but the contents being served are no longer in sync with the documentation sources. Please fix the cause of the error above or press Ctrl+C to stop the server.
[sphinx-autobuild] Serving on http://127.0.0.1:55302
[sphinx-autobuild] Waiting to detect changes...
```

But one thing at a time :)


---

git bisect points to 41a7d8ced2a23a3dc533341a2950209ab871eece (no PR):

```
41a7d8ced2a23a3dc533341a2950209ab871eece is the first bad commit
commit 41a7d8ced2a23a3dc533341a2950209ab871eece
Author: Adam Turner <9087854+aa-turner@users.noreply.github.com>
Date:   Tue Sep 3 02:39:40 2024 -0500

    Prefer ``pathlib``

 sphinx_autobuild/__main__.py | 19 +++++++++----------
 sphinx_autobuild/filter.py   |  4 ++--
 sphinx_autobuild/server.py   | 14 +++-----------
 3 files changed, 14 insertions(+), 23 deletions(-)
```

This looks like the relevant bit:

```diff
     # Copy needed settings
-    args.sourcedir = os.path.realpath(sphinx_args.sourcedir)
-    args.outdir = os.path.realpath(sphinx_args.outputdir)
+    args.sourcedir = Path(sphinx_args.sourcedir).resolve(strict=True)
+    args.outdir = Path(sphinx_args.outputdir).resolve(strict=True)
```

We're just starting up, so the output directory (`build` in my case) might not exist yet. So let's not be strict in resolving it.

https://docs.python.org/3/library/pathlib.html#pathlib.Path.resolve