### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1
 
   tests:
     runs-on: ubuntu-latest
@@ -29,7 +29,7 @@ jobs:
         - "3.13"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
           allow-prereleases: true

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -81,7 +81,7 @@ jobs:
           script: core.setOutput('version', context.ref.replace("refs/tags/", ""))
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: "Release ${{ steps.get_version.outputs.version }}"


### PR DESCRIPTION
Fix these warnings:

> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/setup-python@v4, actions/cache@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/


![image](https://github.com/user-attachments/assets/fe01d627-e456-4f70-ac5f-4805a53c6a01)

https://github.com/sphinx-doc/sphinx-autobuild/actions/runs/10678901212

