### PR TITLE
Fix hot reloading for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ optional-dependencies.docs = [
 ]
 optional-dependencies.test = [
   "httpx",
+  "httpx-ws",
+  "asgi-lifespan",
   "pytest>=6",
 ]
 urls.Changelog = "https://github.com/sphinx-doc/sphinx-autobuild/blob/main/NEWS.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,9 @@ dependencies = [
 optional-dependencies.docs = [
 ]
 optional-dependencies.test = [
+  "asgi-lifespan",
   "httpx",
   "httpx-ws",
-  "asgi-lifespan",
   "pytest>=6",
 ]
 urls.Changelog = "https://github.com/sphinx-doc/sphinx-autobuild/blob/main/NEWS.rst"

--- a/sphinx_autobuild/server.py
+++ b/sphinx_autobuild/server.py
@@ -28,11 +28,11 @@ class RebuildServer:
         self.paths = [Path(path).resolve(strict=True) for path in paths]
         self.ignore = ignore_filter
         self.change_callback = change_callback
-        self.flag = asyncio.Event()
-        self.should_exit = asyncio.Event()
 
     @asynccontextmanager
     async def lifespan(self, _app) -> AbstractAsyncContextManager[None]:
+        self.flag = asyncio.Event()
+        self.should_exit = asyncio.Event()
         task = asyncio.create_task(self.main())
         yield
         self.should_exit.set()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -22,7 +22,7 @@ def anyio_backend():
     return "asyncio"
 
 
-async def test_application(tmp_path, anyio_backend):
+async def test_application(tmp_path, anyio_backend):  # noqa: ARG001
     src_dir = tmp_path / "docs"
     out_dir = tmp_path / "build"
     shutil.copytree(ROOT / "docs", tmp_path / "docs")


### PR DESCRIPTION
Fixes #178

## 1. Move `asyncio.Event` creation to lifespan

This PR moves the creation of the `asyncio.Event` from `RebuildServer.__init__` to `RebuildServer.lifespan`. This ensures `asyncio.Event` is created within the event loop context, resolving the relevant error.

> [!NOTE]
> The error does not occur in Python>=3.10 because the implementation was changed by python/cpython#86558.

## 2. Add rebuild test

Since there was no rebuild test, I added one.

- Added a rebuild test.
  - Added a test to check `refresh` messages from `/websocket-reload` after modifying the `index.rst` file.
- Changed the target test function to an asynchronous function.
  - Starlette's `TestClient` uses threads, while `RebuildServer` uses multiprocessing. In my view, this affected the rebuild test execution and cause it to fail. (0662fc9)
  - Changed Starlette's `TestClient` to `http.AsyncClient`. ([ref](https://www.starlette.io/testclient/#asynchronous-tests))
  - Added test dependencies [`asgi-lifespan`](https://pypi.org/project/asgi-lifespan/) and [`httpx-ws`](https://pypi.org/project/httpx-ws/) required for testing lifespan and WebSocket.