### PR TITLE
Drop support for Python 3.9-3.11 to match Sphinx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.10"
         - "3.11"
         - "3.12"
         - "3.13"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.9"
         - "3.10"
         - "3.11"
         - "3.12"

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,4 @@
-target-version = "py39"  # Pin Ruff to Python 3.9
+target-version = "py310"  # Pin Ruff to Python 3.10
 line-length = 88
 output-format = "full"
 extend-exclude = [
@@ -15,6 +15,7 @@ ignore = [
     "D105",
     "D107",
     "E203",
+    "UP038", # This rule is deprecated and will be removed in a future release.
 #    "W503", # unimplemented in Ruff (as of 2024-04-16)
 ]
 select = [

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,4 @@
-target-version = "py310"  # Pin Ruff to Python 3.10
+target-version = "py311"  # Pin Ruff to Python 3.11
 line-length = 88
 output-format = "full"
 extend-exclude = [

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -27,7 +27,7 @@ Set-up
 
        $ git clone https://github.com/YOUR_USERNAME_HERE/sphinx-autobuild
 
-To work on this project, you need Python 3.9 or newer.
+To work on this project, you need Python 3.10 or newer.
 Most of this project's development workflow commands use nox_.
 
 If you're not sure how to install nox,

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -27,7 +27,7 @@ Set-up
 
        $ git clone https://github.com/YOUR_USERNAME_HERE/sphinx-autobuild
 
-To work on this project, you need Python 3.10 or newer.
+To work on this project, you need Python 3.11 or newer.
 Most of this project's development workflow commands use nox_.
 
 If you're not sure how to install nox,

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -4,7 +4,7 @@ Changelog
 unreleased
 ----------
 
-* Drop support for Python 3.9 to match Sphinx.
+* Drop support for Python 3.9-3.10 to match Sphinx.
 
 2024.10.03 - 2024-10-03
 -----------------------

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -4,6 +4,8 @@ Changelog
 unreleased
 ----------
 
+* Drop support for Python 3.9 to match Sphinx.
+
 2024.10.03 - 2024-10-03
 -----------------------
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,7 @@ def lint(session):
     session.run("pre-commit", "run", "--all-files", *session.posargs)
 
 
-@nox.session(python=["3.10", "3.11", "3.12", "3.13"])
+@nox.session(python=["3.11", "3.12", "3.13"])
 def test(session):
     session.install("-e", ".[test]", silent=True)
     session.run("pytest", *session.posargs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,7 @@ def lint(session):
     session.run("pre-commit", "run", "--all-files", *session.posargs)
 
 
-@nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
+@nox.session(python=["3.10", "3.11", "3.12", "3.13"])
 def test(session):
     session.install("-e", ".[test]", silent=True)
     session.run("pytest", *session.posargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
   { name = "Adam Turner" },
   { name = "Jonathan Stoppani", email = "jonathan@stoppani.name" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
@@ -24,7 +24,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
   { name = "Adam Turner" },
   { name = "Jonathan Stoppani", email = "jonathan@stoppani.name" },
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
@@ -24,7 +24,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
Alternative to https://github.com/sphinx-doc/sphinx-autobuild/pull/182.

Python 3.9 is only receiving security updates and is EOL in October:

https://devguide.python.org/versions/

And Sphinx itself supports 3.11+:

https://www.sphinx-doc.org/en/master/internals/release-process.html#python-version-support-policy

Because Sphinx is an application for generating docs, and not a library dependency, projects can build docs with a single (recent) Python version, even if they support the full 3.9-3.13 range.