### PR TITLE
Fix --help with python 3.14 and sphinx 8.2.3

### DIFF
--- a/sphinx_autobuild/__main__.py
+++ b/sphinx_autobuild/__main__.py
@@ -148,6 +148,10 @@ def _get_sphinx_build_parser():
     sphinx_build_parser.epilog = None
     sphinx_build_parser.prog = "sphinx-autobuild"
     for action in sphinx_build_parser._actions:
+        if hasattr(action, "help"):
+            # Replace _TranslationProxy objects with strings
+            action.help = str(action.help)
+    for action in sphinx_build_parser._actions:
         if hasattr(action, "version"):
             # Fix the version
             action.version = f"%(prog)s {__version__}"


### PR DESCRIPTION
Fixes https://github.com/sphinx-doc/sphinx-autobuild/issues/198.  It seems that only `--help` is affected.  The sphinx help strings assert the existence of translations, which are not provided by sphinx-autobuild.  Convert the `_TranslationProxy` objects into English strings to avoid throwing an exception.
