### PR TITLE
Fix infinite rebuild loop with polling-based file watching

### DIFF
--- a/sphinx_autobuild/server.py
+++ b/sphinx_autobuild/server.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import watchfiles
 from starlette.websockets import WebSocket
+from watchfiles import Change
 
 if TYPE_CHECKING:
     import os
@@ -51,7 +52,10 @@ class RebuildServer:
     async def watch(self) -> None:
         async for changes in watchfiles.awatch(
             *self.paths,
-            watch_filter=lambda _, path: not self.ignore(path),
+            watch_filter=lambda change, path: (
+                (change != Change.modified or Path(path).is_file())
+                and not self.ignore(path)
+            ),
         ):
             changed_paths = [Path(path).resolve() for (_, path) in changes]
             with ProcessPoolExecutor() as pool:


### PR DESCRIPTION
## Problem

When watchfiles is using [polling-based file watching](https://watchfiles.helpmanual.io/api/watch/#watchfiles.watch--force-polling), sphinx-autobuild enters an infinite rebuild loop. This happens because:

1. During a build, file creation inside directories updates their metadata (mtime)
2. watchfiles detects `Change.modified` events for these directories (metadata/mtime changes)
3. sphinx-autobuild triggers a rebuild
4. The rebuild modifies the directories again, creating a loop

## Solution

Modify the `watch_filter` in `RebuildServer.watch()` to ignore `Change.modified` events for directories, while still accepting:

- `Change.modified` only for files (actual content changes)
- `Change.created` and `Change.deleted` for both files and directories (structure changes)
